### PR TITLE
Add configurations to copy new validator-handler jar to the pack

### DIFF
--- a/modules/distribution/product/pom.xml
+++ b/modules/distribution/product/pom.xml
@@ -144,6 +144,29 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.wso2telco.dep</groupId>
+                                    <artifactId>validator-handler</artifactId>
+                                    <version>${com.wso2telco.dep.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target</outputDirectory>
+                                    <destFileName>validator-handler-${com.wso2telco.dep.version}.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                            <!--<outputDirectory>${project.build.directory}/jars</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>-->
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -122,6 +122,13 @@
                 <include>**/Saxon-HE-9.4.jar</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>target</directory>
+            <outputDirectory>wso2telcohub-${pom.version}/repository/components/lib</outputDirectory>
+            <includes>
+                <include>validator-handler-${com.wso2telco.dep.version}.jar</include>
+            </includes>
+        </fileSet>
 	<!-- no need to copy the api-manager.xml since it will be copided by dep.hub.core.feature -->
         <!--fileSet>
             <directory>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/conf</directory>


### PR DESCRIPTION
Note: Please merge this after pull request https://github.com/WSO2Telco/component-dep/pull/164 at component-dep is merged
For new mediation-flow with ESB deployment, we need api_id to be passed to the ESB side.
Inorder to do that we wrote a custom handler called APIInfoHandler.
The following commit will add that validator-handler.jar to product-hub pack under /repository/components/lib.